### PR TITLE
Change postgres npm module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You don't have to, Multicolour uses Waterline as it's ORM and you can switch you
 * `sails-disk`
 * `sails-memory`
 * `sails-redis`
-* `sails-postgres`
+* `sails-postgresql`
 * `sails-mongo`
 * `sails-mysql`
 * `sails-arango`


### PR DESCRIPTION
With `sails-postgres`:
```
npm ERR! 404 Registry returned 404 for GET on https://registry.npmjs.org/sails-postgres
npm ERR! 404 
npm ERR! 404 'sails-postgres' is not in the npm registry.
```

`sails-postgresql` works fine:
https://www.npmjs.com/package/sails-postgresql